### PR TITLE
Feat : 메이트 상세 API 추가

### DIFF
--- a/BackEnd/src/main/java/com/example/backend/controller/MateController.java
+++ b/BackEnd/src/main/java/com/example/backend/controller/MateController.java
@@ -1,5 +1,6 @@
 package com.example.backend.controller;
 
+import com.example.backend.dto.MateDetailDto;
 import com.example.backend.dto.MateRegistDto;
 import com.example.backend.dto.Response;
 import com.example.backend.model.user.User;
@@ -7,6 +8,8 @@ import com.example.backend.security.UserDetailsImpl;
 import com.example.backend.service.MateService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,11 +25,17 @@ public class MateController {
             @RequestBody MateRegistDto.Request request) {
         User user = userDetails.getUser();
 
-        if(user.getType().toString() == "GUIDE"){
+        if (user.getType().toString() == "GUIDE") {
             throw new IllegalArgumentException("가이드는 mate 등록을 할 수 없습니다.");
         }
 
         mateService.registMateService(request, userDetails.getUser());
         return new Response<>("200", "성공적으로 메이트 등록 되었습니다!", null);
+    }
+
+    @GetMapping("/mate/{mateId}")
+    public Response<MateDetailDto.Response> getMateDetail(@PathVariable Long mateId){
+        MateDetailDto.Response response = mateService.getDetailMate(mateId);
+        return new Response<>("200", "성공적으로 메이트 상세를 가져왔습니다.", response);
     }
 }

--- a/BackEnd/src/main/java/com/example/backend/dto/MateDetailDto.java
+++ b/BackEnd/src/main/java/com/example/backend/dto/MateDetailDto.java
@@ -1,0 +1,16 @@
+package com.example.backend.dto;
+
+import java.util.List;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+public class MateDetailDto {
+
+    @Data
+    @NoArgsConstructor
+    public static class Response {
+        private MateInfoDetailDto mate;
+        private List<MateJoinerDto> joiners;
+    }
+}

--- a/BackEnd/src/main/java/com/example/backend/dto/MateInfoDetailDto.java
+++ b/BackEnd/src/main/java/com/example/backend/dto/MateInfoDetailDto.java
@@ -1,0 +1,23 @@
+package com.example.backend.dto;
+
+import com.example.backend.model.mate.Mate;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class MateInfoDetailDto {
+    private Long tourId;
+    private String title;
+    private String content;
+    private int minMember;
+    private int maxMember;
+
+    public MateInfoDetailDto(Mate mate){
+        this.tourId = mate.getTourId();
+        this.title = mate.getTitle();
+        this.content = mate.getContent();
+        this.minMember = mate.getMinMember();
+        this.maxMember = mate.getMaxMember();
+    }
+}

--- a/BackEnd/src/main/java/com/example/backend/dto/MateJoinerDto.java
+++ b/BackEnd/src/main/java/com/example/backend/dto/MateJoinerDto.java
@@ -1,0 +1,21 @@
+package com.example.backend.dto;
+
+import com.example.backend.model.joiner.Joiner;
+import java.util.Date;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class MateJoinerDto {
+    private String profileImg;
+    private String nickname;
+    private Date joinDate;
+
+    public MateJoinerDto(Joiner joiner){
+        this.profileImg = joiner.getUser().getProfileImg();
+        this.nickname = joiner.getUser().getNickname();
+        this.joinDate = joiner.getJoinDate();
+    }
+}

--- a/BackEnd/src/main/java/com/example/backend/model/joiner/Joiner.java
+++ b/BackEnd/src/main/java/com/example/backend/model/joiner/Joiner.java
@@ -9,7 +9,9 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
+import lombok.Data;
 
+@Data
 @Entity
 public class Joiner {
 

--- a/BackEnd/src/main/java/com/example/backend/model/mate/Mate.java
+++ b/BackEnd/src/main/java/com/example/backend/model/mate/Mate.java
@@ -8,8 +8,10 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import lombok.Data;
 import lombok.NoArgsConstructor;
 
+@Data
 @Entity
 @NoArgsConstructor
 public class Mate {

--- a/BackEnd/src/main/java/com/example/backend/security/SecurityConfig.java
+++ b/BackEnd/src/main/java/com/example/backend/security/SecurityConfig.java
@@ -23,6 +23,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.parameters.P;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -122,6 +123,9 @@ public class SecurityConfig {
         skipPathList.add(new Path(HttpMethod.GET, "/ws-stomp/**"));
         skipPathList.add(new Path(HttpMethod.POST, "/ws-stomp/**"));
         skipPathList.add(new Path(HttpMethod.GET, "/ws/**"));
+
+        // Mate
+        skipPathList.add(new Path(HttpMethod.GET, "/mate/**"));
 
         FilterSkipMatcher matcher = new FilterSkipMatcher(skipPathList, "/**");
         JwtAuthFilter filter = new JwtAuthFilter(matcher, extractor);

--- a/BackEnd/src/main/java/com/example/backend/service/MateService.java
+++ b/BackEnd/src/main/java/com/example/backend/service/MateService.java
@@ -1,12 +1,19 @@
 package com.example.backend.service;
 
+import com.example.backend.dto.MateDetailDto;
+import com.example.backend.dto.MateDetailDto.Response;
+import com.example.backend.dto.MateInfoDetailDto;
+import com.example.backend.dto.MateJoinerDto;
 import com.example.backend.dto.MateRegistDto;
+import com.example.backend.model.joiner.Joiner;
 import com.example.backend.model.joiner.JoinerRepository;
 import com.example.backend.model.mate.Mate;
 import com.example.backend.model.mate.MateRepository;
 import com.example.backend.model.tour.Tour;
 import com.example.backend.model.tour.TourRepository;
 import com.example.backend.model.user.User;
+import java.util.ArrayList;
+import java.util.List;
 import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -30,5 +37,25 @@ public class MateService {
 
         Mate mate = new Mate(request, tour, user, joinMember);
         mateRepository.save(mate);
+    }
+
+    public MateDetailDto.Response getDetailMate(Long mateId){
+        Mate mate = mateRepository.findById(mateId).get();
+        MateInfoDetailDto mateInfoDetailDto = new MateInfoDetailDto(mate);
+        List<Joiner> joiners = joinerRepository.findAllByTourId(mate.getTourId());
+        List<MateJoinerDto> mateInfoDetailDtos = new ArrayList<>();
+
+        if(joiners.size() == 0){
+            throw new IllegalArgumentException("Mate 상세 데이터의 joiner의 수가 0일 수 없습니다.");
+        }
+
+        for(Joiner joiner : joiners){
+            mateInfoDetailDtos.add(new MateJoinerDto(joiner));
+        }
+
+        MateDetailDto.Response response = new MateDetailDto.Response();
+        response.setMate(mateInfoDetailDto);
+        response.setJoiners(mateInfoDetailDtos);
+        return response;
     }
 }


### PR DESCRIPTION
- 프론트의 요구사항에 맞게 메이트 상세 데이터를 넘겨줍니다.
- 데이터는 크게 mate와 joiner로 크게 나눠 데이터를 넘겨줍니다.
- mate : 메이트 구하기
- joiner : 메이트 참가자 데이터